### PR TITLE
Modificato DatabaseConnector

### DIFF
--- a/App/backend/database_connector.py
+++ b/App/backend/database_connector.py
@@ -1,21 +1,28 @@
-import streamlit
 import sqlalchemy
 
 class DatabaseConnector:
-    def __init__(self):
-        self.connection = streamlit.connection("sqlite", "sql")
+    engines = {}
+
+    def __init__(self, url: str = "sqlite:///../../db/chatsql.db"):
+        if url not in DatabaseConnector.engines:
+            DatabaseConnector.engines[url] = sqlalchemy.create_engine(url)
+        self.engine = DatabaseConnector.engines[url]
+
 
     def fetchUser(self, username: str):
-        result = self.connection.query("SELECT username, password FROM admins WHERE username = :x", params={"x":username})
-        return result.iloc[0]
+        with self.engine.connect() as connection:
+            result = connection.execute(sqlalchemy.text("SELECT username, password FROM admins WHERE username = :x"), {"x" : username})
+            return result.one_or_none()
 
     def __fetchDictionaryById(self, id: int):
-        result = self.connection.query("SELECT id, name, description FROM dictionaries WHERE id = :x", params={"x":id})
-        return result.iloc[0]
+        with self.engine.connect() as connection:
+            result = connection.execute(sqlalchemy.text("SELECT id, name, description FROM dictionaries WHERE id = :x"), {"x":id})
+            return result.one_or_none()
     
     def __fetchDictionaryByName(self, name: str):
-        result = self.connection.query("SELECT id, name, description FROM dictionaries WHERE name = :x", params={"x":name})
-        return result.iloc[0]
+        with self.engine.connect() as connection:
+            result = connection.query("SELECT id, name, description FROM dictionaries WHERE name = :x", {"x":name})
+            return result.iloc[0]
     
     def fetchDictionary(self, table_field: str, value):
         if(table_field == "id"):
@@ -23,31 +30,31 @@ class DatabaseConnector:
         if(table_field == "name"):
             return self.__fetchDictionaryByName(value)
     
-    def insertDictionary(self, name: str, description: str) -> bool:
+    def insertDictionary(self, name: str, description: str | None = None) -> bool:
         if(name == None or name == ""):
             return False
         try:
-            with self.connection.session as session:
-                session.execute(sqlalchemy.text("INSERT INTO dictionaries(name, description) VALUES (:x, :y)"), {"x" : name, "y": description})
-                session.commit()
+            with self.engine.connect() as connection:
+                connection.execute(sqlalchemy.text("INSERT INTO dictionaries(name, description) VALUES (:x, :y)"), {"x" : name, "y": description})
+                connection.commit()
             return True
         except sqlalchemy.exc.IntegrityError:
                 raise ValueError("A dictionary with that name already exists")
     
-    def __deleteDictionaryById(self, id: int) -> bool:
+    def __deleteDictionaryById(self, id) -> bool:
         if(self.__fetchDictionaryById(id).empty):
             return False
-        with self.connection.session as session:
-            session.execute(sqlalchemy.text("DELETE FROM dictionaries WHERE id = :x"),{"x":id})
-            session.commit()
+        with self.engine.connect() as connection:
+            connection.execute(sqlalchemy.text("DELETE FROM dictionaries WHERE id = :x"), {"x":id})
+            connection.commit()
         return True
         
-    def __deleteDictionaryByName(self, name: str) -> bool:
+    def __deleteDictionaryByName(self, name) -> bool:
         if(self.__fetchDictionaryByName(name).empty):
             return False
-        with self.connection.session as session:
-            session.execute(sqlalchemy.text("DELETE FROM dictionaries WHERE name = :x"),{"x":name})
-            session.commit()
+        with self.engine.connect() as connection:
+            connection.execute(sqlalchemy.text("DELETE FROM dictionaries WHERE name = :x"), {"x":name})
+            connection.commit()
         return True
 
     def deleteDictionary(self, table_field: str, field_value) -> bool:
@@ -61,13 +68,13 @@ class DatabaseConnector:
         validinput =    (key_field == "id" or key_field == "name") and \
                         (update_field == "name" or update_field == "description") and \
                         ((update_value != "" and update_value != None) if update_field == "name" else True) # Additional check for an updated name to be not None or empty
-        if((not validinput) or self.fetchDictionary(key_field, key_value).empty): # Previous checks fail or entry does not exist 
+        if((not validinput) or (self.fetchDictionary(key_field, key_value) is None)): # Previous checks fail or entry does not exist 
             return False
         query = f"UPDATE dictionaries SET {update_field} = :y WHERE {key_field} = :x"
         try:
-            with self.connection.session as session:
-                session.execute(sqlalchemy.text(query), {"x" : key_value, "y" : update_value})
-                session.commit()
+            with self.engine.connect() as connection:
+                connection.execute(sqlalchemy.text(query), {"x" : key_value, "y" : update_value})
+                connection.commit()
             return True
         except sqlalchemy.exc.IntegrityError:
             raise ValueError("A dictionary with that name already exists")

--- a/App/frontend/.streamlit/secrets.toml
+++ b/App/frontend/.streamlit/secrets.toml
@@ -1,2 +1,0 @@
-[connections.sqlite]
-url = "sqlite:///../db/chatsql.db"


### PR DESCRIPTION
[ARGO-103]
Il nuovo DatabaseConnector contiene gli stessi metodi del precedente, è semplicemente stato modificato per essere gestito tramite la libreria SQLAlchemy, ampiamente supportata come libreria per interazione con database SQL.
La differenza principale è nello sviluppo di una mappa interna alla classe che contiene gli engine generati, in quanto è opportuno averne uno solo per ciascuna connessione a database, mentre oggetti di tipo connessione sono unicamente creati dentro ai metodi della classe con statement `with` per rendere le interazioni il più atomiche possibile

[ARGO-103]: https://argo-swe-2.atlassian.net/browse/ARGO-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ