### PR TITLE
bug Vue con docker 'vite not found'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
     links:
       - backend
     volumes:
-      - ./frontend:/usr/src/app
+      - ./frontend/src:/usr/src/app/src
+      - ./frontend/public:/usr/src/app/public
+      - ./frontend/environments:/usr/src/app/environments
+      - ./frontend/index.html:/usr/src/app/index.html
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,9 +13,6 @@ COPY package*.json ./
 
 RUN npm ci
 
-# Bundle app source
-COPY . .
-
 EXPOSE 8080
 
 CMD [ "npm", "run", "dev"]


### PR DESCRIPTION
Replica della situazione che portava all'errore:

1. scaricando la repo da zero (assicurarsi di non avere la cartella `frontend/node_modules` altrimenti il bug viene risolto in automatico
2. ricreare l'immagine docker del frontend
    ```
    docker compose build --no-cache frontend
    ```
3. avviare frontend e backend
    ```
    docker compose up
    ```